### PR TITLE
fix Bottom app gif not loading

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -27,7 +27,7 @@ IP/hostname
 
 A customizable cross-platform graphical process/system monitor for the terminal
 
-![bottom demo](https://github.com/ClementTsang/bottom/blob/master/assets/demo.gif?raw=true)
+![bottom demo](https://github.com/ClementTsang/bottom/blob/main/assets/demo.gif?raw=true)
 
 ---
 


### PR DESCRIPTION
Bottom renamed the main branch from master to main, the redirect in GitHub does not work for URLs using `raw=true`

<img width="746" alt="image" src="https://github.com/user-attachments/assets/3d10352b-80fd-4d4b-ba27-dbd4bce7353a">
